### PR TITLE
feature/serve frontend assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "build": "bun build src/index.ts --target=node --outfile dist/gakuon",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun run build && bun run build:client",
     "fmt": "bunx biome format --write ./src",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "build": "bun build src/index.ts --target=node --outfile dist/gakuon",
-    "prepublishOnly": "bun run build && bun run build:client",
+    "prepublishOnly": "rm -rf dist && bun run build && bun run build:client",
     "fmt": "bunx biome format --write ./src",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/client/views/DeckView.tsx
+++ b/src/client/views/DeckView.tsx
@@ -396,7 +396,6 @@ export function DeckView() {
                 </button>
               ))}
             </div>
-
           </div>
         </div>
       )}
@@ -415,7 +414,7 @@ export function DeckView() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
           <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full">
             <h2 className="text-xl font-bold mb-4 dark:text-white">Settings</h2>
-            
+
             <div className="mb-4">
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 API Base URL

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -8,6 +8,7 @@ import type { Server } from "node:http";
 interface ServeOptions {
   port?: string;
   debug?: boolean;
+  serveClient?: boolean;
 }
 
 export async function serve(options: ServeOptions = {}) {
@@ -29,6 +30,7 @@ export async function serve(options: ServeOptions = {}) {
     contentManager,
     debug,
     config,
+    serveClient: options.serveClient,
   });
 
   let server: Server | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ program
   .description("Start the Gakuon HTTP server")
   .option("-p, --port <number>", "Port to listen on", "4989")
   .option("-d, --debug", "Enable debug mode")
+  .option("--serve-client", "Serve built client app from dist/client")
   .action(serve);
 
 program.parse();

--- a/src/services/server/app.ts
+++ b/src/services/server/app.ts
@@ -38,11 +38,11 @@ export function createServer(deps: ServerDependencies) {
     // Try multiple possible locations for client files
     const possiblePaths = [
       // Development path
-      new URL("../../client/dist/client", import.meta.url).pathname,
+      join(__dirname, "../../client/dist/client"),
       // Installed package path
-      new URL("../../../client", import.meta.url).pathname,
+      join(__dirname, "../../../client"),
       // Built package path
-      new URL("../client", import.meta.url).pathname
+      join(__dirname, "../client"),
     ];
 
     let clientPath = null;
@@ -62,9 +62,6 @@ export function createServer(deps: ServerDependencies) {
       console.warn("Could not find client files to serve");
     } else {
       app.use(express.static(clientPath));
-      app.get("/", (_req, res) =>
-        res.sendFile("index.html", { root: clientPath })
-      );
     }
   }
 

--- a/src/services/server/app.ts
+++ b/src/services/server/app.ts
@@ -33,6 +33,15 @@ export function createServer(deps: ServerDependencies) {
   app.use(cors());
   app.use(express.json());
 
+  if (deps.serveClient) {
+    const clientPath = new URL("../../client/dist/client", import.meta.url)
+      .pathname;
+    app.use(express.static(clientPath));
+    app.get("/", (_req, res) =>
+      res.sendFile("index.html", { root: clientPath }),
+    );
+  }
+
   // Debug logging
   if (deps.debug) {
     app.use((req, _res, next) => {

--- a/src/services/server/app.ts
+++ b/src/services/server/app.ts
@@ -13,6 +13,7 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { writeFile, unlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
 
 async function saveBase64ToTemp(base64Data: string): Promise<string> {
   // Create a unique filename
@@ -34,12 +35,37 @@ export function createServer(deps: ServerDependencies) {
   app.use(express.json());
 
   if (deps.serveClient) {
-    const clientPath = new URL("../../client/dist/client", import.meta.url)
-      .pathname;
-    app.use(express.static(clientPath));
-    app.get("/", (_req, res) =>
-      res.sendFile("index.html", { root: clientPath }),
-    );
+    // Try multiple possible locations for client files
+    const possiblePaths = [
+      // Development path
+      new URL("../../client/dist/client", import.meta.url).pathname,
+      // Installed package path
+      new URL("../../../client", import.meta.url).pathname,
+      // Built package path
+      new URL("../client", import.meta.url).pathname
+    ];
+
+    let clientPath = null;
+    for (const path of possiblePaths) {
+      try {
+        const indexPath = join(path, "index.html");
+        if (existsSync(indexPath)) {
+          clientPath = path;
+          break;
+        }
+      } catch (e) {
+        // Continue trying paths
+      }
+    }
+
+    if (!clientPath) {
+      console.warn("Could not find client files to serve");
+    } else {
+      app.use(express.static(clientPath));
+      app.get("/", (_req, res) => 
+        res.sendFile("index.html", { root: clientPath })
+      );
+    }
   }
 
   // Debug logging

--- a/src/services/server/app.ts
+++ b/src/services/server/app.ts
@@ -62,7 +62,7 @@ export function createServer(deps: ServerDependencies) {
       console.warn("Could not find client files to serve");
     } else {
       app.use(express.static(clientPath));
-      app.get("/", (_req, res) => 
+      app.get("/", (_req, res) =>
         res.sendFile("index.html", { root: clientPath })
       );
     }

--- a/src/services/server/types.ts
+++ b/src/services/server/types.ts
@@ -9,6 +9,7 @@ export interface ServerDependencies {
   contentManager: ContentManager;
   config: GakuonConfig;
   debug?: boolean;
+  serveClient?: boolean;
 }
 
 export interface APIError {

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,8 @@ export default defineConfig({
   root: './src/client/',
   plugins: [react(), tailwindcss()],
   build: {
-    outDir: 'dist/client',
+    outDir: '../../dist/client',
+    emptyOutDir: true,
   },
   server: {
     port: 5173,

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   root: './src/client/',
   plugins: [react(), tailwindcss()],
   build: {
-    outDir: '../../dist/client',
+    outDir: './dist/client',
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
fixes #30

- **feat: Add option to serve built client app from dist/client directory**
- **fix: Improve client file path resolution for global npm installation**
- **fix: revert vite output**
- **chore: use __dirname**
